### PR TITLE
FIx wrong number of analyzed files

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![License](https://img.shields.io/github/license/kube-security/orca)](https://github.com/kube-security/orca/blob/main/LICENSE)
 [![Latest Release](https://img.shields.io/github/v/release/kube-security/orca?sort=semver)](https://github.com/kube-security/orca/releases)
 
-<img src="docs/orca.png" alt="ORCA logo" style="width:30%; height:auto;">
+<img src="docs/orca.png" alt="ORCA logo" style="width:20%; height:auto;">
 
 ORCA is a tool designed to analyze obfuscated or obscure container images, providing reliable Software Bill of Materials (SBOMs) even when traditional tools fail. It addresses the challenge of container image obfuscation and empowers developers and security teams to better manage and secure containerized environments.
 
@@ -51,7 +51,7 @@ Once installed, ORCA can be used to scan container images.
 
 ```bash
 orca --help
-usage: orca [-h] [-d DIR] [--csv CSV] [-b] containers
+usage: orca [-h] [-d DIR] [--csv] [-b] [-c] containers
 
 Software composition analysis for containers
 
@@ -61,8 +61,9 @@ positional arguments:
 options:
   -h, --help           show this help message and exit
   -d DIR, --dir DIR    Folder where to store results *without ending /*
-  --csv CSV            Store also a csv file with package information
+  --csv                Store also a csv file with package information
   -b, --with-binaries  Analyze every binary file (slower). Go binaries are always analyzed
+  -c, --complete       Generate complete SPDX report with relationships (>200MB file is generated)
 ```
 
 Example usage: `orca alpine:latest`

--- a/orca/find_cpes.py
+++ b/orca/find_cpes.py
@@ -142,11 +142,22 @@ def scan_os(paths: List[str],directory: str)-> None:
         return osinfo 
     return None
 
-def scan_filesystem(directory,analyze_binaries=False,accurate=False) -> VulnerabilityReport:
+def scan_filesystem(directory: str,files,analyze_binaries=False,accurate=False) -> VulnerabilityReport:
+    """
+        Scans the filesystem to identify and analyze files, extract dependencies, and generate a vulnerability report.
+        Args:
+            directory (str): The root directory to scan for files. This directory does not contain links or devices.
+            files (list): A list of files to analyze. This includes also links and devices.
+            analyze_binaries (bool, optional): Whether to analyze binary files for dependencies. Defaults to False.
+            accurate (bool, optional): Whether to perform additional steps to remove duplicate files for more accurate results. Defaults to False.
+        Returns:
+            VulnerabilityReport: A report containing information about identified vulnerabilities, packages, and remaining files.
+       
+    """
     paths: Set[str] = get_filepaths(directory)
 
 
-    report: VulnerabilityReport = VulnerabilityReport(paths)
+    report: VulnerabilityReport = VulnerabilityReport(paths,files)
     
     osinfo = scan_os(report.remaining_files,directory)
     if osinfo is not None:
@@ -201,7 +212,7 @@ def scan_filesystem(directory,analyze_binaries=False,accurate=False) -> Vulnerab
     return report
 
 
-def get_cpes(directory,analyze_binaries=False,store_cpes=True,store_cpe_files=True,accurate=False,analyze_cves=False):
+def get_cpes(directory: str,analyze_binaries=False,store_cpes=True,store_cpe_files=True,accurate=False,analyze_cves=False):
 
     report:VulnerabilityReport = scan_filesystem(directory,analyze_binaries,accurate) 
     pkgset = list(set(report.packages))

--- a/orca/lib/spdx.py
+++ b/orca/lib/spdx.py
@@ -175,7 +175,7 @@ def generateRelationships(reportMap: Dict[str,VulnerabilityReport],filemap: Dict
 
 
 
-def generateSPDXFromReportMap(containerImage: str,reportMap: Dict[str,VulnerabilityReport],output_filename: str):
+def generateSPDXFromReportMap(containerImage: str,reportMap: Dict[str,VulnerabilityReport],output_filename: str,complete_report: bool):
 
     osinfo = getOsInfo(reportMap)
     if osinfo is not None and "version" not in osinfo:
@@ -190,13 +190,12 @@ def generateSPDXFromReportMap(containerImage: str,reportMap: Dict[str,Vulnerabil
 
 
    
-    relmap = generateRelationships(reportMap,filemap,packagesmap,osinfo)  
-
+   
 
     
      
     packages = list(packagesmap.values())
-    relationships = list(relmap.values())
+
     packages.append(containerPackage)
     if osinfo is not None:
         osPackage: Package = Package(name=osinfo["name"].split(" ")[0].lower(),
@@ -206,8 +205,13 @@ def generateSPDXFromReportMap(containerImage: str,reportMap: Dict[str,Vulnerabil
 
     files = list(filemap.values())
     
-    doc = Document(creation_info,packages=packages,relationships=relationships,
-                   files=files)
+    doc = None
+    if complete_report:
+        relmap = generateRelationships(reportMap,filemap,packagesmap,osinfo)  
+        relationships = list(relmap.values())
+        doc = Document(creation_info,packages=packages,relationships=relationships,files=files)
+    else:
+        doc = Document(creation_info,packages=packages,files=files)
     
     write_file(doc, output_filename,validate=False)
     #write_file(doc, output_filename,validate=True)

--- a/orca/lib/types.py
+++ b/orca/lib/types.py
@@ -86,10 +86,11 @@ class VulnerabilityReport:
 
     def add_package_files(self,package_files: Dict[PackageInfo,List[str]]):
         self.packages.extend(package_files.keys())
-        self.package_files.update(package_files)
+        self.package_files.update({pkg: files for pkg, files in package_files.items() if any(f in self.initial_files for f in files)}) # TODO: probably add the other files to another dict
         fs = [file for file_list in package_files.values() for file in file_list ]
-        self.analyzed_files.update(fs)
-        self.remaining_files = self.remaining_files.difference(fs)
+        fs_in_initial = [f for f in fs if f in self.initial_files]
+        self.analyzed_files.update(fs_in_initial)
+        self.remaining_files = self.remaining_files.difference(fs_in_initial)
     
     def to_json(self):
         json_dict = {}

--- a/orca/lib/types.py
+++ b/orca/lib/types.py
@@ -110,5 +110,5 @@ class VulnerabilityReport:
         return json_dict
     
     def summary(self) -> str:
-        return f"Found {len(self.original_files)} packages. Indexed {len(self.analyzed_files)} filed over a total of {len(self.original_files)} - Remaining files {len(self.original_files) - len(self.analyzed_files)}"
+        return f"Found {len(self.packages)} packages. Indexed {len(self.analyzed_files)} files over a total of {len(self.original_files)} - Remaining files {len(self.original_files) - len(self.analyzed_files)}"
 

--- a/orca/lib/types.py
+++ b/orca/lib/types.py
@@ -71,9 +71,14 @@ class PackageInfo:
         return f"{self.name},{self.version},{author}"
 
 class VulnerabilityReport:
-    def __init__(self,paths: Set[str]):
+    def __init__(self,paths: Set[str],files=None):
+        if files is not None:
+            self.original_files = files
+        else:
+            self.original_files = paths
         self.initial_files = paths
         self.remaining_files = paths
+        assert isinstance(self.remaining_files, set), "remaining_files must be a set"
         self.packages: List[PackageInfo] = []
         self.package_files: Dict[PackageInfo,List[str]] = {}
         self.analyzed_files: Set[str] = set()
@@ -105,5 +110,5 @@ class VulnerabilityReport:
         return json_dict
     
     def summary(self) -> str:
-        return f"Found {len(self.packages)} packages. Indexed {len(self.analyzed_files)} filed over a total of {len(self.initial_files)} - Remaining files {len(self.initial_files) - len(self.analyzed_files)}"
+        return f"Found {len(self.original_files)} packages. Indexed {len(self.analyzed_files)} filed over a total of {len(self.original_files)} - Remaining files {len(self.original_files) - len(self.analyzed_files)}"
 

--- a/orca/main.py
+++ b/orca/main.py
@@ -169,7 +169,7 @@ def write_logfile(report_by_layer: dict[str, VulnerabilityReport],container:str,
             json.dump(loginfo,fp)
 
 
-def orca(client: docker.DockerClient,output_folder: str,csv:bool,binary_analysis:bool,containers: List[str]):
+def orca(client: docker.DockerClient,output_folder: str,csv:bool,binary_analysis:bool,with_complete_report:bool,containers: List[str]):
  
  if not os.path.exists("logs/"):
     os.mkdir("logs",mode=0o755)
@@ -208,7 +208,7 @@ def orca(client: docker.DockerClient,output_folder: str,csv:bool,binary_analysis
                        fp.write(pkg.to_csv_entry() + "\n")
                    fp.close()
         
-        generateSPDXFromReportMap(container,report_by_layer,f"{output_folder}/orca-{container_usable_name}.json")
+        generateSPDXFromReportMap(container,report_by_layer,f"{output_folder}/orca-{container_usable_name}.json",with_complete_report)
 
 
 def main():
@@ -222,11 +222,14 @@ def main():
         "-d","--dir", type=str, help="Folder where to store results *without ending /*",default="results")
     
     parser.add_argument(
-        "--csv", type=bool, help="Store also a csv file with package information",default=False)
+        "--csv", action='store_true', help="Store also a csv file with package information",default=False)
     
     parser.add_argument(
        "-b","--with-binaries", action='store_true', help="Analyze every binary file (slower). Go binaries are always analyzed",default=False)
-
+    
+    parser.add_argument(
+        "-c","--complete", action='store_true', help="Generate complete SPDX report with relationships (>200MB file is generated)", default=False)
+    
     parser.add_argument(
         "containers", type=str, help="Comma separated list of containers to analyze")
 
@@ -235,8 +238,9 @@ def main():
     output = args.dir
     csv = args.csv
     with_bin = args.with_binaries
+    with_complete_report = args.complete
     containers = args.containers.split(",")
-    orca(client,output,csv,with_bin,containers)
+    orca(client,output,csv,with_bin,with_complete_report,containers)
 
 if __name__ == "__main__":
     main()

--- a/orca/main.py
+++ b/orca/main.py
@@ -103,6 +103,11 @@ def scan_tar(image_tar:str,client:docker.DockerClient,binary_analysis:bool):
         logger.info(report.summary())
 
     cpes = extract_cpes_from_dockerfile_with_validation(config)
+    # FIXME: this is a hack to make the report work with the dockerfile. Obfiously Dockerfile commands are not files. 
+    cpes.remaining_files = set()
+    cpes.initial_files = set()
+    cpes.original_files = set()
+    report_by_layer["Dockerfile"] = cpes
     report_by_layer["Dockerfile"] = cpes
 
     # Cleanup: TODO: probably should be done in a separate function
@@ -130,6 +135,11 @@ def scan_image(container:str,client:docker.DockerClient,binary_analysis:bool):
         logger.info(report.summary())
 
     cpes = extract_cpes_from_dockerfile_with_validation(config)
+    report_by_layer["Dockerfile"] = cpes
+    # FIXME: this is a hack to make the report work with the dockerfile. Obfiously Dockerfile commands are not files. 
+    cpes.remaining_files = set()
+    cpes.initial_files = set()
+    cpes.original_files = set()
     report_by_layer["Dockerfile"] = cpes
     # Cleanup: TODO: probably should be done in a separate function
     shutil.rmtree(TMP_DIR,ignore_errors=True)

--- a/orca/main.py
+++ b/orca/main.py
@@ -96,7 +96,8 @@ def scan_tar(image_tar:str,client:docker.DockerClient,binary_analysis:bool):
             continue
         image_layer = tarfile.open(f"{TMP_DIR}/{layer}")
         image_layer.extractall(f"{TMP_DIR}/{layer}_layer",filter=tar_remove_links,numeric_owner=True)
-        report = scan_filesystem(f"{TMP_DIR}/{layer}_layer",binary_analysis,False)
+        image_files = image_layer.getnames()
+        report = scan_filesystem(f"{TMP_DIR}/{layer}_layer",image_files,binary_analysis,False)
         report_by_layer[layer] = report
         # Add dockerfile:
         logger.info(report.summary())
@@ -122,7 +123,8 @@ def scan_image(container:str,client:docker.DockerClient,binary_analysis:bool):
             continue
         image_layer = tarfile.open(f"{TMP_DIR}/{layer}")
         image_layer.extractall(f"{TMP_DIR}/{layer}_layer",filter=tar_remove_links)
-        report = scan_filesystem(f"{TMP_DIR}/{layer}_layer",binary_analysis,False)
+        image_files = image_layer.getnames()
+        report = scan_filesystem(f"{TMP_DIR}/{layer}_layer",image_files, binary_analysis,False)
         report_by_layer[layer] = report
 
         logger.info(report.summary())


### PR DESCRIPTION
ORCA removes links and devices from each layer (tar archive). This creates a mismatch between what orca finds (in e.g., dpkg/status) and the layer content. This PR fixes that. 